### PR TITLE
Add rename script and associated github action.

### DIFF
--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -1,0 +1,34 @@
+# GitHub Actions Workflow responsible for cleaning up a new KBase module.
+# Based on a similar workflow in JetBrains/intellij-platform-plugin-template.
+
+name: Template Cleanup
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  # Run cleaning process only if workflow is triggered by a new project
+  template-cleanup:
+    name: Template Cleanup
+    runs-on: ubuntu-latest
+    if: github.event.repository.name != 'example_sdk_app'
+    steps:
+
+      # Check out current repository
+      - name: Fetch Sources
+        uses: actions/checkout@v2
+
+      # Cleanup project
+      - name: Cleanup
+        run: |
+          bash scripts/rename.sh
+          rm .github/workflows/template-cleanup.yml
+
+      # Push changes
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          branch: main
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
 # example_kb_sdk_app
 
-This repo demonstrates some best practices for writing KBase Apps, as well as providing a simple app that demonstrates
-uploading data into kbase, using kbase utilities, using an external script, and using biopython to do simple calculations within the app.
+This repo demonstrates some best practices for writing KBase Apps, as well as
+providing a simple app that demonstrates uploading data into kbase, using kbase
+utilities, using an external script, and using biopython to do simple
+calculations within the app.
+
+## Quick start
+
+1. Make a new project using this repository as a template. *NOTE*: Do not use
+   `example_sdk_app` in the name.
+2. Wait for the github action to finish, see details below.
+3. Clone your repository locally. Be sure the name of the local directory is
+    the same as the repository name.
+4. Run `kb-sdk test`.
+5. Add your token to `test.cfg` and your repository secrets.
+6. Run `kb-sdk test`.
+
+## Philosophy
 
 We also aim to demonstrate various practicies, such as
 
@@ -21,7 +36,9 @@ We also aim to demonstrate various practicies, such as
 * New Base Image
 * Updated Makefile to enable testing with `pytest` instead of the deprecated `nose`
 
+## FAQ
 
+### How does the github action work?
 
 ## TODO
 

--- a/scripts/rename.sh
+++ b/scripts/rename.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+if [ -z "$GITHUB_ACTION" ]; then
+  echo This script should only be run as a github action.
+  exit 1;
+fi
+
+# This script is meant to be run once immediately after cloning this repo.
+set -e
+set -x
+
+# TODO: Infer app name from directory.
+name=$(basename $(pwd))
+
+FILES=$(cat << HEREDOC
+Makefile
+RELEASE_NOTES.md
+deploy.cfg
+example_kb_sdk_app.spec
+kbase.yml
+lib/example_kb_sdk_app/example_kb_sdk_appImpl.py
+lib/example_kb_sdk_app/example_kb_sdk_appServer.py
+scripts/run_async.sh
+test/example_kb_sdk_app_server_test.py
+test/unit_tests/test_example_kb_sdk_app_utils.py
+tox.ini
+ui/narrative/methods/run_example_kb_sdk_app/spec.json
+HEREDOC
+)
+
+for file in $FILES
+do
+    sed -i'.bak' "s/example_kb_sdk_app/${name}/g" ${file}
+done
+
+git add -u
+
+git mv example_kb_sdk_app.spec ${name}.spec
+git mv lib/example_kb_sdk_app/example_kb_sdk_appImpl.py lib/example_kb_sdk_app/${name}Impl.py
+git mv lib/example_kb_sdk_app/example_kb_sdk_appServer.py lib/example_kb_sdk_app/${name}Server.py
+git mv lib/example_kb_sdk_app lib/${name}
+git mv test/example_kb_sdk_app_server_test.py test/${name}_server_test.py
+git mv test/unit_tests/test_example_kb_sdk_app_utils.py test/unit_tests/test_${name}_utils.py
+git mv ui/narrative/methods/run_example_kb_sdk_app ui/narrative/methods/run_${name}
+
+echo "# ${name}" > README.md
+
+git add --update
+OLD_GIT_USER_EMAIL=$(git config --get user.email)
+OLD_GIT_USER_NAME=$(git config --get user.name)
+git config user.email "KBase@example.com"
+git config user.name "KBase"
+
+# Delete this script
+git rm -- "$0"
+
+git commit --message="Renaming example module to ${name}."
+git config user.email "$OLD_GIT_USER_EMAIL"
+git config user.name "$OLD_GIT_USER_NAME"


### PR DESCRIPTION
This PR addresses #11. It adds a github action which will run a rename script when this repository is used as a template. This will streamline the KBase module creation process. Then both the script and the action deletes itself and commits the changes. What is left is a module ready to be used as a starting point for the KB SDK tutorial.